### PR TITLE
Release of CIS_AL2 and CIS_AL2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ Detailed steps are inside each pattern folder, but the overall steps for each pa
 
 **Step 1.** Users run `make run-static-tests` command for static code analysis tests
 
-**Step 2.** Users run `make plan/apply` to deploy VPC resource using Terraform.
+**Step 2.** Users run `make plan` and `make apply` to deploy VPC resource using Terraform.
 
 **Step 3.** Users run `make create-hardened-ami` to create security-hardened Amazon EKS AMIs using Packer using one of the methods outlined below.
 
-**Step 4.** Users run `make cluster-plan/cluster-apply` to create EKS Cluster and create EKS managed node groups for each security-hardened Amazon EKS AMI as part of the same EKS Cluster. This also will deploy several different apps and add-ons and will run tests to see if the workload will run without issues.
+**Step 4.** Users run `make cluster-plan` and `make cluster-apply` to create EKS Cluster and create EKS managed node groups for each security-hardened Amazon EKS AMI as part of the same EKS Cluster. This also will deploy several different apps and add-ons and will run tests to see if the workload will run without issues.
 
 **Step 5.** Users run `make run-cis-scan` to trigger AWS Inspector CIS scans to scan EKS manages nodes and generate reports about checks which Passed, are Skipped or Failed.
 

--- a/patterns/CIS_AL2/Makefile
+++ b/patterns/CIS_AL2/Makefile
@@ -49,7 +49,7 @@ apply: init
 create-hardened-ami:
 	@echo "Creating Hardened AMIs..."
 	@if [ ! -d "amazon-eks-ami" ]; then \
-		git clone https://github.com/awslabs/amazon-eks-ami.git --branch v20250519; \
+		git clone https://github.com/awslabs/amazon-eks-ami.git --branch v20250627; \
 	fi
 	@packer plugins install github.com/hashicorp/amazon || true
 	@cd amazon-eks-ami && { \

--- a/patterns/CIS_AL2/Makefile
+++ b/patterns/CIS_AL2/Makefile
@@ -54,12 +54,12 @@ create-hardened-ami:
 	@packer plugins install github.com/hashicorp/amazon || true
 	@cd amazon-eks-ami && { \
 		timestamp=$$(date +%s); \
-		ami_name="CIS_Amazon_Linux_2_Kernel_4_Benchmark_Level_1-$$timestamp"; \
+		ami_name="CIS_Amazon_Linux_2_Benchmark_Level_1-$$timestamp"; \
 		sed -i -e 's#sudo chmod +x $$binary#sudo chmod 755 $$binary#g' templates/al2/provisioners/install-worker.sh; \
 		sed -i -e 's#aws --version#sudo /bin/aws --version#g' templates/shared/provisioners/generate-version-info.sh; \
 		AMI_ID=$$(aws ec2 describe-images \
 			--owners aws-marketplace \
-			--filters "Name=architecture,Values=x86_64" "Name=name,Values=CIS Amazon Linux 2 Kernel 4.14 Benchmark - Level 1 - v01*" \
+			--filters "Name=architecture,Values=x86_64" "Name=name,Values=CIS Amazon Linux 2 Kernel 5.10 Benchmark - Level 1 - v06*" \
 			--query 'sort_by(Images, &CreationDate)[-1].ImageId' \
 			--region $(AWS_REGION) \
 			--output text); \
@@ -67,7 +67,7 @@ create-hardened-ami:
 			aws_region=$(AWS_REGION) \
 			source_ami_id=$$AMI_ID \
 			source_ami_owners=679593333241 \
-			source_ami_filter_name="CIS Amazon Linux 2 Kernel 4.14 Benchmark - Level 1 - v01*" \
+			source_ami_filter_name="CIS Amazon Linux 2 Kernel 5.10 Benchmark - Level 1 - v06*" \
 			AMI_VARIANT=amazon-eks-cis \
 			subnet_id=$(SUBNET_ID) \
 			launch_block_device_mappings_volume_size=15 \
@@ -86,7 +86,7 @@ create-hardened-ami:
 		ami_name="CIS_Amazon_Linux_2_Benchmark_Level_2-$$timestamp"; \
 		AMI_ID=$$(aws ec2 describe-images \
 			--owners aws-marketplace \
-			--filters "Name=architecture,Values=x86_64" "Name=name,Values=CIS Amazon Linux 2 Kernel 5.10 Benchmark - Level 2 - v04*" \
+			--filters "Name=architecture,Values=x86_64" "Name=name,Values=CIS Amazon Linux 2 Kernel 5.10 Benchmark - Level 2 - v06*" \
 			--query 'sort_by(Images, &CreationDate)[-1].ImageId' \
 			--region $(AWS_REGION) \
 			--output text); \
@@ -94,7 +94,7 @@ create-hardened-ami:
 			aws_region=$(AWS_REGION) \
 			source_ami_id=$$AMI_ID \
 			source_ami_owners=679593333241 \
-			source_ami_filter_name="CIS Amazon Linux 2 Kernel 5.10 Benchmark - Level 2 - v04*" \
+			source_ami_filter_name="CIS Amazon Linux 2 Kernel 5.10 Benchmark - Level 2 - v06*" \
 			subnet_id=$(SUBNET_ID) \
 			launch_block_device_mappings_volume_size=15 \
 			associate_public_ip_address=true \

--- a/patterns/CIS_AL2/README.md
+++ b/patterns/CIS_AL2/README.md
@@ -13,7 +13,7 @@ This pattern provides a fully automated solution to create security-hardened Ama
 
 For Level 1:
 
-- [CIS Amazon Linux 2 Kernel 4.14 Benchmark - Level 1](https://aws.amazon.com/marketplace/pp/prodview-5ihz572adcm7i?sr=0-2&ref_=beagle&applicationId=AWSMPContessa)
+- [CIS Hardened Image Level 1 on Amazon Linux 2 Kernel 5.10](https://aws.amazon.com/marketplace/server/procurement?productId=abcfcbaf-134e-4639-a7b4-fd285b9fcf0a)
 
 For Level 2:
 

--- a/patterns/CIS_AL2/eks-cluster/main.tf
+++ b/patterns/CIS_AL2/eks-cluster/main.tf
@@ -35,7 +35,7 @@ provider "kubernetes" {
 
 }
 
-data "aws_ssm_parameter" "cis_amazon_linux_2_kernel_4_benchmark_level_1" {
+data "aws_ssm_parameter" "cis_amazon_linux_2_benchmark_level_1" {
   name = "/cis_ami/${local.name}/CIS_Amazon_Linux_2_Benchmark_Level_1/ami_id"
 }
 data "aws_ssm_parameter" "cis_amazon_linux_2_benchmark_level_2" {
@@ -53,7 +53,7 @@ module "eks_managed_node_group_level_1" {
   depends_on = [module.eks_cluster]
 
   source = "terraform-aws-modules/eks/aws//modules/eks-managed-node-group"
-  version = "~> 20.36" #ensure to update this to the latest/desired version
+  version = "20.37.1" #ensure to update this to the latest/desired version
 
   name            = "CISAL2K4BL1"
   cluster_name    = module.eks_cluster.cluster_name
@@ -73,7 +73,7 @@ module "eks_managed_node_group_level_1" {
     AmazonInspector2ManagedCisPolicy = "arn:aws:iam::aws:policy/AmazonInspector2ManagedCisPolicy"
   }
 
-  ami_id = data.aws_ssm_parameter.cis_amazon_linux_2_kernel_4_benchmark_level_1.value
+  ami_id = data.aws_ssm_parameter.cis_amazon_linux_2_benchmark_level_1.value
 
   instance_types             = ["m6i.large", "m5.large", "m5zn.large"]
   capacity_type              = "SPOT"
@@ -99,7 +99,7 @@ module "eks_managed_node_group_level_2" {
   depends_on = [module.eks_cluster]
 
   source = "terraform-aws-modules/eks/aws//modules/eks-managed-node-group"
-  version = "~> 20.36" #ensure to update this to the latest/desired version
+  version = "20.37.1" #ensure to update this to the latest/desired version
 
   name            = "CISAL2BL2"
   cluster_name    = module.eks_cluster.cluster_name

--- a/patterns/CIS_AL2/eks-cluster/versions.tf
+++ b/patterns/CIS_AL2/eks-cluster/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.96"
+      version = "5.100.0"
     }
   }
   backend "s3" {

--- a/patterns/CIS_AL2/versions.tf
+++ b/patterns/CIS_AL2/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.96"
+      version = "5.100.0"
     }
   }
   backend "s3" {

--- a/patterns/CIS_AL2023/Makefile
+++ b/patterns/CIS_AL2023/Makefile
@@ -48,7 +48,7 @@ apply: init
 create-hardened-ami:
 	@echo "Creating Hardened AMIs..."
 	@if [ ! -d "amazon-eks-ami" ]; then \
-		git clone https://github.com/awslabs/amazon-eks-ami.git --branch v20250519; \
+		git clone https://github.com/awslabs/amazon-eks-ami.git --branch v20250627; \
 	fi
 	@packer plugins install github.com/hashicorp/amazon || true
 	@cd amazon-eks-ami && { \

--- a/patterns/CIS_AL2023/Makefile
+++ b/patterns/CIS_AL2023/Makefile
@@ -66,7 +66,7 @@ create-hardened-ami:
         sed -i -e 's#cache-pause-container#sudo cache-pause-container#g' templates/al2023/provisioners/cache-pause-container.sh; \
 		AMI_ID=$$(aws ec2 describe-images \
 			--owners aws-marketplace \
-			--filters "Name=architecture,Values=x86_64" "Name=name,Values=CIS Amazon Linux 2023 Benchmark - Level 1 - v05*" \
+			--filters "Name=architecture,Values=x86_64" "Name=name,Values=CIS Amazon Linux 2023 Benchmark - Level 1 - v06*" \
 			--query 'sort_by(Images, &CreationDate)[-1].ImageId' \
 			--region $(AWS_REGION) \
 			--output text); \
@@ -75,7 +75,7 @@ create-hardened-ami:
 			aws_region=$(AWS_REGION) \
 			source_ami_id=$$AMI_ID \
 			source_ami_owners=679593333241 \
-			source_ami_filter_name="CIS Amazon Linux 2023 Benchmark - Level 1 - v05**" \
+			source_ami_filter_name="CIS Amazon Linux 2023 Benchmark - Level 1 - v06**" \
 			subnet_id=$(SUBNET_ID) \
 			associate_public_ip_address=true \
 			remote_folder=/home/ec2-user \
@@ -98,7 +98,7 @@ create-hardened-ami:
 		ami_name="CIS_Amazon_Linux_2023_Benchmark_Level_2-$$timestamp"; \
 		AMI_ID=$$(aws ec2 describe-images \
 			--owners aws-marketplace \
-			--filters "Name=architecture,Values=x86_64" "Name=name,Values=CIS Amazon Linux 2023 Benchmark - Level 2 - v05*" \
+			--filters "Name=architecture,Values=x86_64" "Name=name,Values=CIS Amazon Linux 2023 Benchmark - Level 2 - v06*" \
 			--query 'sort_by(Images, &CreationDate)[-1].ImageId' \
 			--region $(AWS_REGION) \
 			--output text) && \
@@ -108,7 +108,7 @@ create-hardened-ami:
 			aws_region=$(AWS_REGION) \
 			source_ami_id=$$AMI_ID \
 			source_ami_owners=679593333241 \
-			source_ami_filter_name="CIS Amazon Linux 2023 Benchmark - Level 2 - v05*" \
+			source_ami_filter_name="CIS Amazon Linux 2023 Benchmark - Level 2 - v06*" \
 			subnet_id=$(SUBNET_ID) \
 			associate_public_ip_address=true \
 			remote_folder=/home/ec2-user \

--- a/patterns/CIS_AL2023/eks-cluster/main.tf
+++ b/patterns/CIS_AL2023/eks-cluster/main.tf
@@ -52,7 +52,7 @@ module "eks_cluster" {
 module "eks_managed_node_group_level_1" {
   depends_on                        = [module.eks_cluster]
   source                            = "terraform-aws-modules/eks/aws//modules/eks-managed-node-group"
-  version = "~> 20.36" #ensure to update this to the latest/desired version
+  version = "20.37.1" #ensure to update this to the latest/desired version
   name                              = "CISAL2023BL1"
   cluster_name                      = module.eks_cluster.cluster_name
   cluster_version                   = module.eks_cluster.cluster_version
@@ -97,7 +97,7 @@ module "eks_managed_node_group_level_1" {
 module "eks_managed_node_group_level_2" {
   depends_on = [module.eks_cluster]
   source     = "terraform-aws-modules/eks/aws//modules/eks-managed-node-group"
-  version = "~> 20.36" #ensure to update this to the latest/desired version
+  version = "20.37.1" #ensure to update this to the latest/desired version
 
   name                              = "CISAL2023BL2"
   cluster_name                      = module.eks_cluster.cluster_name

--- a/patterns/CIS_AL2023/eks-cluster/versions.tf
+++ b/patterns/CIS_AL2023/eks-cluster/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.96"
+      version = "5.100.0"
     }
   }
   backend "s3" {

--- a/patterns/CIS_AL2023/versions.tf
+++ b/patterns/CIS_AL2023/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.96"
+      version = "5.100.0"
     }
   }
   backend "s3" {


### PR DESCRIPTION
Solution has been tested considering the following dependencies versions:

- hashicorp/aws 5.100.0
- terraform-aws-modules/vpc/aws 5.21.0
- terraform-aws-modules/eks/aws 20.37.1
- aws-ia/eks-blueprints-addons/aws 1.21.1
- Terraform v1.12.2
- Packer v1.13.1

### **Pattern CIS_AL2:**

- EKS Version: 1.32

**CIS Level 1:**

- Source AMI Name: CIS Amazon Linux 2 Kernel 5.10 Benchmark - Level 1 - v06
- EKS Scripts: https://github.com/awslabs/amazon-eks-ami/releases/tag/v20250627

**CIS Level 2:**

- Source AMI Name: CIS Amazon Linux 2 Kernel 5.10 Benchmark - Level 2 - v06
- EKS Scripts: https://github.com/awslabs/amazon-eks-ami/releases/tag/v20250627

### Pattern **CIS_AL2023:**

EKS Version: 1.33

**CIS Level 1:**

- Source AMI Name: CIS Amazon Linux 2023 Benchmark - Level 1 - v06
- EKS Scripts: https://github.com/awslabs/amazon-eks-ami/releases/tag/v20250627

**CIS Level 2:**

- Source AMI Name: CIS Amazon Linux 2023 Benchmark - Level 2 - v06
- EKS Scripts: https://github.com/awslabs/amazon-eks-ami/releases/tag/v20250627
